### PR TITLE
Import Data.Generic.Rep from prelude

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "purescript-fixed-points": "main",
     "purescript-datetime": "master",
-    "purescript-generics-rep": "master",
     "purescript-transformers": "master",
     "purescript-lists": "master",
     "purescript-prelude": "master",

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,7 +6,6 @@
   , "datetime"
   , "effect"
   , "fixed-points"
-  , "generics-rep"
   , "lists"
   , "numbers"
   , "parsing"

--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -32,12 +32,12 @@ import Data.Formatter.Internal (foldDigits)
 import Data.Formatter.Parser.Number (parseDigit)
 import Data.Formatter.Parser.Utils (runP, oneOfAs)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
 import Data.Int as Int
 import Data.List as List
 import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.Newtype (unwrap)
 import Data.Ord (abs)
+import Data.Show.Generic (genericShow)
 import Data.String as Str
 import Data.String.CodeUnits as CU
 import Data.Time as T
@@ -320,7 +320,7 @@ parseSignedInt ∷ ∀ m
   → P.ParserT String m Int
 parseSignedInt maxLength validators errMsg = do
   isNegative ← isJust <$> PC.optionMaybe (PS.char '-')
-  (if isNegative then negate else identity) <$> parseInt maxLength validators errMsg 
+  (if isNegative then negate else identity) <$> parseInt maxLength validators errMsg
 
 parseInt ∷ ∀ m
   . Monad m

--- a/src/Data/Formatter/Number.purs
+++ b/src/Data/Formatter/Number.purs
@@ -22,10 +22,10 @@ import Data.Formatter.Internal (foldDigits, repeat)
 import Data.Formatter.Parser.Number (parseDigit)
 import Data.Formatter.Parser.Utils (runP)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
 import Data.Int as Int
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.Newtype (class Newtype)
+import Data.Show.Generic (genericShow)
 import Data.String as Str
 import Data.String.CodeUnits as CU
 import Data.Traversable (for)
@@ -87,11 +87,11 @@ formatParser = do
 -- means of showing an integer potentially larger than +/- 2 billion.
 foreign import showNumberAsInt :: Number -> String
 
--- | Formats a number according to the format object provided. 
--- | Due to the nature of floating point numbers, may yield unpredictable results for extremely 
+-- | Formats a number according to the format object provided.
+-- | Due to the nature of floating point numbers, may yield unpredictable results for extremely
 -- | large or extremely small numbers, such as numbers whose absolute values are ≥ 1e21 or ≤ 1e-21,
--- | or when formatting with > 20 digits after the decimal place.  
--- | See [purescript-decimals](https://pursuit.purescript.org/packages/purescript-decimals/4.0.0) 
+-- | or when formatting with > 20 digits after the decimal place.
+-- | See [purescript-decimals](https://pursuit.purescript.org/packages/purescript-decimals/4.0.0)
 -- | for working with arbitrary precision decimals, which supports simple number
 -- | formatting for numbers that go beyond the precision available with `Number`.
 format ∷ Formatter → Number → String


### PR DESCRIPTION
**Description of the change**
We merged generics-rep into prelude and renamed the Data.Generic.Rep.* modules to Data.*.Generic in https://github.com/purescript/purescript-prelude/pull/235.
