### PR TITLE
Add support for one-digit month

### DIFF
--- a/src/Data/Formatter/DateTime.purs
+++ b/src/Data/Formatter/DateTime.purs
@@ -53,6 +53,7 @@ data FormatterCommand
   | YearAbsolute
   | MonthFull
   | MonthShort
+  | MonthDigit
   | MonthTwoDigits
   | DayOfMonthTwoDigits
   | DayOfMonth
@@ -87,6 +88,7 @@ printFormatterCommand = case _ of
   YearAbsolute → "Y"
   MonthFull → "MMMM"
   MonthShort → "MMM"
+  MonthDigit → "M"
   MonthTwoDigits → "MM"
   DayOfMonthTwoDigits → "DD"
   DayOfMonth → "D"
@@ -127,6 +129,7 @@ formatterCommandParser = (PC.try <<< PS.string) `oneOfAs`
   , Tuple "MMMM" MonthFull
   , Tuple "MMM" MonthShort
   , Tuple "MM" MonthTwoDigits
+  , Tuple "M" MonthDigit
   , Tuple "DD" DayOfMonthTwoDigits
   , Tuple "D" DayOfMonth
   , Tuple "E" DayOfWeek
@@ -170,6 +173,7 @@ formatCommand dt@(DT.DateTime d t) = case _ of
   YearAbsolute → show $ fromEnum $ D.year d
   MonthFull → show $ D.month d
   MonthShort → printShortMonth $ D.month d
+  MonthDigit -> show $ fromEnum $ D.month d
   MonthTwoDigits → padSingleDigit $ fromEnum $ D.month d
   DayOfMonthTwoDigits → padSingleDigit $ fromEnum $ D.day d
   DayOfMonth → show $ fromEnum $ D.day d
@@ -351,6 +355,8 @@ unformatCommandParser = case _ of
     (fromEnum <$> parseMonth)
   MonthShort → _{month = _} `modifyWithParser`
     (fromEnum <$> parseShortMonth)
+  MonthDigit →  _{month = _} `modifyWithParser`
+    (parseInt 2 (validateRange 1 12) "Incorrect month digit")
   MonthTwoDigits → _{month = _} `modifyWithParser`
     (parseInt 2 (validateRange 1 12 <> exactLength) "Incorrect 2-digit month")
   DayOfMonthTwoDigits → _{day = _} `modifyWithParser`


### PR DESCRIPTION
**Description of the change**
Adds support for one-digit months, e.g. `"20.5.2020"`. This is pretty lenient, as `"20.05.2020"` will format nicely too 😁

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
