### PR TITLE
parsing v7.0.0 no StringLike class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
-Upgrade to parsing v7.0.0, replace all `StringLike` constraints with `String` type (#76)
+- Upgrade to parsing v7.0.0, replace all `StringLike` constraints with `String` type (#76 by @jamesdbrock)
 
 New features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 
+Upgrade to parsing v7.0.0, replace all `StringLike` constraints with `String` type (#76)
+
 New features:
 
 Bugfixes:

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "purescript-fixed-points": "^6.0.0",
     "purescript-lists": "^6.0.0",
     "purescript-numbers": "^8.0.0",
-    "purescript-parsing": "^6.0.0",
+    "purescript-parsing": "^7.0.0",
     "purescript-prelude": "^5.0.0",
     "purescript-transformers": "^5.0.0"
   },

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,3 +2,4 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
 
 in  upstream
+  with parsing.version = "v7.0.0"

--- a/src/Data/Formatter/Parser/Number.purs
+++ b/src/Data/Formatter/Parser/Number.purs
@@ -19,26 +19,26 @@ import Data.Maybe (Maybe(..))
 import Data.Number (fromString)
 import Data.Foldable (foldMap)
 
-parseInteger ∷ ∀ s m. Monad m ⇒ PS.StringLike s ⇒ P.ParserT s m Int
+parseInteger ∷ ∀ m. Monad m ⇒ P.ParserT String m Int
 parseInteger = some parseDigit <#> foldDigits
 
-parseMaybeInteger ∷ ∀ s m. Monad m ⇒ PS.StringLike s ⇒ P.ParserT s m (Maybe Int)
+parseMaybeInteger ∷ ∀ m. Monad m ⇒ P.ParserT String m (Maybe Int)
 parseMaybeInteger = PC.optionMaybe parseInteger
 
-parseFractional ∷ ∀ s m. Monad m ⇒ PS.StringLike s ⇒ P.ParserT s m Number
+parseFractional ∷ ∀ m. Monad m ⇒ P.ParserT String m Number
 parseFractional = do
   digitStr <- (some parseDigit) <#> (foldMap show >>> ("0." <> _))
   case fromString digitStr of
       Just n -> pure n
       Nothing -> P.fail ("Not a number: " <> digitStr)
 
-parseNumber ∷ ∀ s m. Monad m ⇒ PS.StringLike s ⇒ P.ParserT s m Number
+parseNumber ∷ ∀ m. Monad m ⇒ P.ParserT String m Number
 parseNumber = (+)
   <$> (parseInteger <#> toNumber)
   <*> (PC.option 0.0 $ PC.try $ PS.oneOf ['.', ','] *> parseFractional)
 
 
-parseDigit ∷ ∀ s m. Monad m ⇒ PS.StringLike s ⇒ P.ParserT s m Int
+parseDigit ∷ ∀ m. Monad m ⇒ P.ParserT String m Int
 parseDigit = PC.try $ PS.char `oneOfAs`
   [ Tuple '0' 0
   , Tuple '1' 1

--- a/src/Data/Formatter/Parser/Utils.purs
+++ b/src/Data/Formatter/Parser/Utils.purs
@@ -17,7 +17,7 @@ import Data.Either (Either)
 oneOfAs ∷ ∀ c s m f a b. Functor f ⇒ Foldable f ⇒ Monad m ⇒ (a → ParserT s m b) → f (Tuple a c) → ParserT s m c
 oneOfAs p xs = PC.choice $ (\(Tuple s r) → p s $> r) <$> xs
 
-runP ∷ ∀ s a. PS.StringLike s ⇒ Parser s a → s → Either String a
+runP ∷ ∀ a. Parser String a → String → Either String a
 runP p s = lmap printError $ runParser s (p <* PS.eof)
 
 printError ∷ ParseError → String


### PR DESCRIPTION
**Description of the change**

Upgrade parsing dependency to v7.0.0, remove the `StringLike` class. https://github.com/purescript-contrib/purescript-parsing/releases/tag/v7.0.0

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
